### PR TITLE
README.md update, newer distros will require that (libfl-dev/flex-devel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Quickstart
 
 Ubuntu packages needed:
 
-	$ sudo apt-get install autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev
+	$ sudo apt-get install autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev libusb-1.0-0-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev device-tree-compiler pkg-config libexpat-dev libfl-dev
 
 Fedora packages needed:
 
-	$ sudo dnf install autoconf automake @development-tools curl dtc libmpc-devel mpfr-devel gmp-devel libusb-devel gawk gcc-c++ bison flex texinfo gperf libtool patchutils bc zlib-devel expat-devel
+	$ sudo dnf install autoconf automake @development-tools curl dtc libmpc-devel mpfr-devel gmp-devel libusb-devel gawk gcc-c++ bison flex texinfo gperf libtool patchutils bc zlib-devel expat-devel flex-devel
 
 _Note:_ This requires a compiler with C++11 support (e.g. GCC >= 4.8).
 To use a compiler different than the default, use:


### PR DESCRIPTION
I was not able to simulate rocket-chip (and compile software) under <Linux Mint 19.1 Tessa>.

Error:

```
V3Lexer_pregen.yy.cpp:369:10: fatal error: FlexLexer.h: No such file or directory
 #include <FlexLexer.h>
          ^~~~~~~~~~~~~
```

Steps to reproduce:

$ #(Linux Mint 19.1 Tessa)
$ #(check out rocket-chip) #9ddb76e40ddf13308d33d23f0cdd77c32521b7d7
$ cd emulator
$ make -jN run-asm-tests-debug

Solution:

Install libfl-dev (flex-devel on Fedora).

**Hence, I just added this information to the README.md file.**